### PR TITLE
PR: Review Fixes and Cleanup for Blender Extensions Compliance

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,0 @@
-# On-Screen Numpad v1.1.0
-
-Initial release of a Blender addon that lets you enter numbers without leaving the mouse. Simply press `Ctrl + Right Click` over any numeric property to open a calculator-enabled numpad with math functions and angle conversion support.
-
-For detailed features and usage instructions, see [README.md](README.md).

--- a/__init__.py
+++ b/__init__.py
@@ -5,7 +5,7 @@ from .keymaps import register_keymaps, unregister_keymaps
 from .menu_integration import cleanup_menu_on_reload, register_menu, unregister_menu
 from .operators import WM_OT_numeric_input, WM_OT_numeric_input_key
 from .preferences import OnScreenNumpadPreferences
-from .utils.ui_utils import CopyTextToClipboardOperator
+from .utils.ui_utils import OSN_OT_copy_text_to_clipboard
 
 bl_info = {
     "name": "On-Screen Numpad",
@@ -23,7 +23,7 @@ classes = [
     OnScreenNumpadPreferences,
     WM_OT_numeric_input,
     WM_OT_numeric_input_key,
-    CopyTextToClipboardOperator,
+    OSN_OT_copy_text_to_clipboard,
 ]
 
 cleanup_on_reload()

--- a/__init__.py
+++ b/__init__.py
@@ -10,7 +10,7 @@ from .utils.ui_utils import OSN_OT_copy_text_to_clipboard
 bl_info = {
     "name": "On-Screen Numpad",
     "author": "Pluglug",
-    "version": (1, 1, 0),
+    "version": (1, 2, 0),
     "blender": (4, 2, 0),
     "location": "Numeric Property Fields",
     "description": "No need to leave the mouse to enter numbers!",
@@ -18,6 +18,12 @@ bl_info = {
     "wiki_url": "",
     "category": "User Interface",
 }
+
+# Version update checklist (when bumping version)
+# - [ ] Update bl_info["version"]
+# - [ ] Update version in blender_manifest.toml
+# - [ ] Update blender_version_max if needed
+# - [ ] Update Version badge in README.md
 
 classes = [
     OnScreenNumpadPreferences,

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,4 @@
-import bpy
+from bpy.utils import register_class, unregister_class
 
 from .core import cleanup_on_reload
 from .keymaps import register_keymaps, unregister_keymaps
@@ -32,7 +32,7 @@ cleanup_menu_on_reload()
 
 def register():
     for cls in classes:
-        bpy.utils.register_class(cls)
+        register_class(cls)
     register_menu()
     register_keymaps()
 
@@ -45,4 +45,4 @@ def unregister():
     unregister_keymaps()
     unregister_menu()
     for cls in reversed(classes):
-        bpy.utils.unregister_class(cls)
+        unregister_class(cls)

--- a/addon.py
+++ b/addon.py
@@ -4,6 +4,7 @@ import os
 from typing import TYPE_CHECKING
 
 import bpy
+from bpy.types import Context
 
 if TYPE_CHECKING:
     from .preferences import OnScreenNumpadPreferences
@@ -13,7 +14,7 @@ from .utils.logging import get_logger
 ADDON_PATH = os.path.dirname(os.path.abspath(__file__))
 
 
-def get_prefs(context: bpy.types.Context = None) -> "OnScreenNumpadPreferences":
+def get_prefs(context: Context = None) -> "OnScreenNumpadPreferences":
     """
     Get addon preferences
 

--- a/addon.py
+++ b/addon.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import os
-import re
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING
 
 import bpy
 
@@ -12,71 +11,32 @@ if TYPE_CHECKING:
 from .utils.logging import get_logger
 
 ADDON_PATH = os.path.dirname(os.path.abspath(__file__))
-ADDON_ID = os.path.basename(ADDON_PATH)
-ADDON_PREFIX = "".join([s[0] for s in re.split(r"[_-]", ADDON_ID)]).upper()
-ADDON_PREFIX_PY = ADDON_PREFIX.lower()
-
-_TARGET_NAME_NORM = ADDON_ID.replace("-", "_")
 
 
-def _is_target_addon(key: str) -> bool:
-    base = key.split(".")[-1]
-    return base.replace("-", "_") == _TARGET_NAME_NORM
-
-
-_PREFS_CACHE: Dict[int, "OnScreenNumpadPreferences"] = {}
-
-
-def get_uprefs(context: bpy.types.Context = bpy.context) -> bpy.types.Preferences:
-    """
-    Get user preferences
-
-    Args:
-        context: Blender context (defaults to bpy.context)
-
-    Returns:
-        bpy.types.Preferences: User preferences
-
-    Raises:
-        AttributeError: If preferences cannot be accessed
-    """
-    preferences = getattr(context, "preferences", None)
-    if preferences is not None:
-        return preferences
-    raise AttributeError("Could not access preferences")
-
-
-def get_prefs(context: bpy.types.Context = bpy.context) -> OnScreenNumpadPreferences:
+def get_prefs(context: bpy.types.Context = None) -> "OnScreenNumpadPreferences":
     """
     Get addon preferences
 
     Args:
-        context: Blender context (defaults to bpy.context)
+        context: Blender context (optional, defaults to bpy.context)
 
     Returns:
         OnScreenNumpadPreferences: Addon preferences
 
     Raises:
-        KeyError: If addon is not found
+        KeyError: If addon preferences cannot be accessed
     """
-    user_prefs = get_uprefs(context)
+    if context is None:
+        context = bpy.context
 
-    cache_key = id(user_prefs)
-    prefs_cached = _PREFS_CACHE.get(cache_key)
-    if prefs_cached is not None:
-        return prefs_cached
-
-    for key, addon in user_prefs.addons.items():
-        if _is_target_addon(key):
-            _PREFS_CACHE[cache_key] = addon.preferences
-            return addon.preferences
-
-    raise KeyError(f"Addon/Extension '{ADDON_ID}' not found in user preferences.")
+    try:
+        return context.preferences.addons[__package__].preferences
+    except KeyError:
+        raise KeyError(f"Addon preferences for '{__package__}' not found")
 
 
 def init_addon():
     """Initialize addon settings after registration"""
-
     try:
         prefs = get_prefs()
         log = get_logger()

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "on_screen_numpad"
-version = "1.1.0"
+version = "1.2.0"
 name = "On-Screen Numpad"
 tagline = "No need to leave the mouse to enter numbers"
 maintainer = "Pluglug"

--- a/operators.py
+++ b/operators.py
@@ -48,7 +48,7 @@ class WM_OT_numeric_input(Operator):
 
         # Set property information
         if not calculator.detect_property_from_context(context):
-            self.report({"ERROR"}, "Failed to get property information")
+            self.report({"ERROR"}, "Unsupported property")
             return {"CANCELLED"}
 
         # Check property type (type validation for hotkey invocation)

--- a/operators.py
+++ b/operators.py
@@ -24,22 +24,15 @@ class WM_OT_numeric_input(Operator):
     @classmethod
     def poll(cls, context):
         """Check if operator can be executed"""
-        # Allow if calculator is already open
         calculator = CalculatorState.get_instance()
-        if calculator.current_property:
+
+        if calculator.get_popup():
             return True
 
-        # Check normal property context
-        ptr = getattr(context, "button_pointer", None)
-        prop = getattr(context, "button_prop", None)
-        if ptr and prop and prop.type in {"INT", "FLOAT"}:
+        if calculator.is_numeric_property_available(context):
             return True
 
-        # For hotkey invocation: use copy_data_path_button poll
-        try:
-            return bpy.ops.ui.copy_data_path_button.poll()
-        except Exception:
-            return False
+        return False
 
     def invoke(self, context, event):
         """Display calculator dialog"""

--- a/utils/ui_utils.py
+++ b/utils/ui_utils.py
@@ -2,11 +2,10 @@ import textwrap
 
 import bpy
 from bpy.app import version as BL_VERSION
+from bpy.props import StringProperty
 from bpy.types import Operator, UILayout
 
-from ..addon import ADDON_PREFIX, ADDON_PREFIX_PY
 from ..utils.logging import get_logger
-
 
 log = get_logger(__name__)
 
@@ -37,14 +36,18 @@ def _indented_layout(layout, level):
 
 
 class CopyTextToClipboard:
-    """テキストをクリップボードにコピーするオペレーター"""
+    """テキストをクリップボードにコピーするオペレーター
 
-    bl_idname = f"{ADDON_PREFIX_PY}.copy_text_to_clipboard"
+    継承して使用する場合は、bl_idnameを各アドオンで固有の値に設定してください。
+    例: bl_idname = "my_addon.copy_text_to_clipboard"
+    """
+
+    bl_idname = "wm.copy_text_to_clipboard"
     bl_label = "Copy to Clipboard"
     bl_description = "Copy text to clipboard"
     bl_options = {"REGISTER"}
 
-    text: bpy.props.StringProperty(
+    text: StringProperty(
         name="Text", description="Text to copy to clipboard", default=""
     )
 
@@ -59,11 +62,8 @@ class CopyTextToClipboard:
         return {"FINISHED"}
 
 
-CopyTextToClipboardOperator = type(
-    f"{ADDON_PREFIX}_OT_copy_text_to_clipboard",
-    (CopyTextToClipboard, Operator),
-    {},
-)
+class OSN_OT_copy_text_to_clipboard(CopyTextToClipboard, Operator):
+    bl_idname = "osn.copy_text_to_clipboard"
 
 
 def ic(icon):
@@ -212,7 +212,7 @@ def ui_multiline_text(
         copy_row.scale_x = 0.8
 
         copy_op = copy_row.operator(
-            CopyTextToClipboardOperator.bl_idname, text="", icon="COPYDOWN"
+            OSN_OT_copy_text_to_clipboard.bl_idname, text="", icon="COPYDOWN"
         )
         copy_op.text = text
 


### PR DESCRIPTION
This PR addresses key issues raised in the Blender Extensions review:

### Compliance Fixes

* **Removed `eval()`**
  Replaced with `_parse_blender_path()` for safe, explicit parsing of `bpy.*` paths. [`1b0753d`](1b0753d940d19a448facb7842dd2fff0cf08e2fb)

* **Corrected preferences access**
  Now uses `context.preferences.addons[__package__].preferences` as per standard API. [`18319a7`](18319a73d276eda737c3f36607877bc544bb99b7)

* **Operator IDs**
  Replaced dynamic tags with fixed `"osn."` prefix to improve stability. [`01b0d60`](01b0d6029bb4846560e5aabc3a20fcc59029729c)

### Internal Cleanup & Refactors

* Version bumped to `1.2.0`, with upgrade checklist.
* Improved poll logic and popup state reset for consistency.
* Unified numeric type checks and simplified logic.
* Reorganized panel drawing code internally.
* Misc: clarified error messages, minor import cleanup.
